### PR TITLE
Auto-propagate pre-release v0.2.0-pre to release-qa

### DIFF
--- a/.github/workflows/release-semver.yaml
+++ b/.github/workflows/release-semver.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create and Merge Pull Request to release-qa
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
           HEAD_BRANCH: ${{ steps.qa_branch.outputs.branch_name }}
           BASE_BRANCH: release-qa
           NEW_TAG: ${{ needs.tag.outputs.version }}


### PR DESCRIPTION
Automatic propagation from release branch for pre-release tag v0.2.0-pre (Commit: ).